### PR TITLE
AREA-62 - Fix flutter android compilation

### DIFF
--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -8,15 +8,15 @@ plugins {
 android {
     namespace = "com.example.triggo"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+        jvmTarget = JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/mobile/android/gradle/wrapper/gradle-wrapper.properties
+++ b/mobile/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip

--- a/mobile/android/settings.gradle
+++ b/mobile/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
+    id "com.android.application" version "8.7.3" apply false
     id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 


### PR DESCRIPTION
I fixed our flutter android app by upgrading packages. It's was a real pain because today, **EVEN** if you create a brand new project from the latest SDK and JDK, the build will failed if you add some ✨specials✨ packages.

Our issue was on the `flutter_secure_storage` package, but now it's fixed with some newer gradle packages.