### PR TITLE
AREA-72 - Add a navigation Bar with all linked pages

### DIFF
--- a/mobile/assets/icons/bolt.svg
+++ b/mobile/assets/icons/bolt.svg
@@ -1,0 +1,3 @@
+<svg data-slot="icon" fill="none" stroke-width="1.5" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <path stroke-linecap="round" stroke-linejoin="round" d="m3.75 13.5 10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75Z"></path>
+</svg>

--- a/mobile/assets/icons/home.svg
+++ b/mobile/assets/icons/home.svg
@@ -1,0 +1,3 @@
+<svg data-slot="icon" fill="none" stroke-width="1.5" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"></path>
+</svg>

--- a/mobile/assets/icons/link.svg
+++ b/mobile/assets/icons/link.svg
@@ -1,0 +1,3 @@
+<svg data-slot="icon" fill="none" stroke-width="1.5" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244"></path>
+</svg>

--- a/mobile/lib/app/features/automations/view/automation_page.view.dart
+++ b/mobile/lib/app/features/automations/view/automation_page.view.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:triggo/app/widgets/scaffold.triggo.dart';
+
+class AutomationPage extends StatefulWidget {
+  const AutomationPage({super.key});
+
+  @override
+  State<AutomationPage> createState() => _IntegrationPageState();
+}
+
+class _IntegrationPageState extends State<AutomationPage> {
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(body: Center(child: Text("Automation Page")));
+  }
+}

--- a/mobile/lib/app/features/card/bloc/card_bloc.dart
+++ b/mobile/lib/app/features/card/bloc/card_bloc.dart
@@ -1,0 +1,18 @@
+import 'package:bloc/bloc.dart';
+
+part 'card_event.dart';
+
+class CardBloc extends Bloc<CardEvent, bool> {
+  CardBloc() : super(false) {
+    on<CardEvent>((event, emit) {
+      switch (event) {
+        case CardEvent.press:
+          emit(true);
+          break;
+        case CardEvent.release:
+          emit(false);
+          break;
+      }
+    });
+  }
+}

--- a/mobile/lib/app/features/card/bloc/card_event.dart
+++ b/mobile/lib/app/features/card/bloc/card_event.dart
@@ -1,0 +1,3 @@
+part of 'card_bloc.dart';
+
+enum CardEvent { press, release }

--- a/mobile/lib/app/features/home/view/home_page.view.dart
+++ b/mobile/lib/app/features/home/view/home_page.view.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:triggo/app/routes/routes_names.dart';
+import 'package:triggo/app/widgets/scaffold.triggo.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -11,41 +11,14 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      _counter++;
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.primaryContainer,
-        title: Text(widget.title),
-      ),
+    return BaseScaffold(
       body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text('$_counter', style: Theme.of(context).textTheme.titleLarge),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.of(context).pushNamedAndRemoveUntil(
-                    RoutesNames.integrations, (route) => false);
-              },
-              child: const Text('Go to Integration page'),
-            )
-          ],
+        child: Text(
+          "Home Page",
+          style: Theme.of(context).textTheme.titleLarge,
         ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
       ),
     );
   }

--- a/mobile/lib/app/features/integrations/view/integration_page.view.dart
+++ b/mobile/lib/app/features/integrations/view/integration_page.view.dart
@@ -4,6 +4,7 @@ import 'package:triggo/app/features/integrations/integration.names.dart';
 import 'package:triggo/app/routes/routes_names.dart';
 import 'package:triggo/app/widgets/banner.triggo.dart';
 import 'package:triggo/app/widgets/button.triggo.dart';
+import 'package:triggo/app/widgets/scaffold.triggo.dart';
 import 'package:triggo/mediator/integration.mediator.dart';
 import 'package:triggo/models/integration.model.dart';
 import 'package:triggo/models/integrations/discord.integration.model.dart';
@@ -23,7 +24,7 @@ class _IntegrationPageState extends State<IntegrationPage> {
     final Future<List<Integration>> integrations =
         integrationMediator.getIntegrations();
 
-    return Scaffold(
+    return BaseScaffold(
       body: Padding(
         padding: const EdgeInsets.all(8.0),
         child: SafeArea(

--- a/mobile/lib/app/routes/generate.routes.dart
+++ b/mobile/lib/app/routes/generate.routes.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:triggo/app/features/automations/view/automation_page.view.dart';
 import 'package:triggo/app/features/home/home.dart';
 import 'package:triggo/app/features/integrations/view/integration_page.view.dart';
 import 'package:triggo/app/features/login/view/login_screen.dart';
@@ -21,6 +22,8 @@ Route<dynamic> generateRoute(RouteSettings settings) {
       return MaterialPageRoute(builder: (_) => const RegisterScreen());
     case (RoutesNames.integrations):
       return MaterialPageRoute(builder: (_) => const IntegrationPage());
+    case (RoutesNames.automations):
+      return MaterialPageRoute(builder: (_) => const AutomationPage());
     default:
       return MaterialPageRoute(builder: (_) => const Placeholder());
   }

--- a/mobile/lib/app/routes/routes_names.dart
+++ b/mobile/lib/app/routes/routes_names.dart
@@ -6,4 +6,5 @@ class RoutesNames {
   static const String register = "register_screen";
   static const String integrations = "integrations_screen";
   static const String connectIntegration = "connect_integration_screen";
+  static const String automations = "automations_screen";
 }

--- a/mobile/lib/app/theme/colors/colors.dart
+++ b/mobile/lib/app/theme/colors/colors.dart
@@ -17,3 +17,4 @@ const ColorScheme triggoColorScheme = ColorScheme(
 );
 
 const Color textColor = Color(0xFF3E244A);
+const Color lightContainer = Color(0xFFF4EBFD);

--- a/mobile/lib/app/widgets/navigation_bar.triggo.dart
+++ b/mobile/lib/app/widgets/navigation_bar.triggo.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:triggo/app/features/card/bloc/card_bloc.dart';
 import 'package:triggo/app/routes/routes_names.dart';
 import 'package:triggo/app/theme/colors/colors.dart';
+
+final ValueNotifier<String?> currentRouteNotifier =
+    ValueNotifier<String?>(RoutesNames.home);
 
 class TriggoNavigationBar extends StatelessWidget {
   const TriggoNavigationBar({super.key});
@@ -40,46 +41,38 @@ class _TriggoNavigationBarItem {
       {required this.iconAsset, required this.routeName});
 
   Widget build(BuildContext context) {
-    return BlocProvider(
-      create: (_) => CardBloc(),
-      child: Builder(
-        builder: (context) {
-          return Expanded(
-            child: GestureDetector(
-              onTap: () {
-                if (ModalRoute.of(context)?.settings.name != routeName) {
-                  Navigator.of(context).pushNamedAndRemoveUntil(
-                      routeName, (route) => route.settings.name == routeName);
-                }
-              },
-              onTapDown: (_) => context.read<CardBloc>().add(CardEvent.press),
-              onTapUp: (_) => context.read<CardBloc>().add(CardEvent.release),
-              onTapCancel: () =>
-                  context.read<CardBloc>().add(CardEvent.release),
-              child: BlocBuilder<CardBloc, bool>(
-                builder: (context, isPressed) {
-                  return Card(
-                    color: isPressed ? lightContainer : Colors.grey[100],
-                    child: SizedBox(
-                      height: 80,
-                      child: Center(
-                        child: SvgPicture.asset(
-                          iconAsset,
-                          color: isPressed
-                              ? Theme.of(context).colorScheme.primary
-                              : Theme.of(context).textTheme.titleMedium?.color,
-                          width: 32,
-                          height: 32,
-                        ),
-                      ),
-                    ),
-                  );
-                },
+    return ValueListenableBuilder<String?>(
+      valueListenable: currentRouteNotifier,
+      builder: (context, currentRoute, child) {
+        final bool isSelected = currentRoute == routeName;
+        return Expanded(
+          child: GestureDetector(
+            onTap: () {
+              if (currentRoute != routeName) {
+                currentRouteNotifier.value = routeName;
+                Navigator.of(context).pushNamedAndRemoveUntil(
+                    routeName, (route) => route.settings.name == routeName);
+              }
+            },
+            child: Card(
+              color: isSelected ? lightContainer : Colors.grey[100],
+              child: SizedBox(
+                height: 80,
+                child: Center(
+                  child: SvgPicture.asset(
+                    iconAsset,
+                    color: isSelected
+                        ? Theme.of(context).colorScheme.primary
+                        : Theme.of(context).textTheme.titleMedium?.color,
+                    width: 32,
+                    height: 32,
+                  ),
+                ),
               ),
             ),
-          );
-        },
-      ),
+          ),
+        );
+      },
     );
   }
 }

--- a/mobile/lib/app/widgets/navigation_bar.triggo.dart
+++ b/mobile/lib/app/widgets/navigation_bar.triggo.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:triggo/app/features/card/bloc/card_bloc.dart';
+import 'package:triggo/app/routes/routes_names.dart';
+import 'package:triggo/app/theme/colors/colors.dart';
+
+class TriggoNavigationBar extends StatelessWidget {
+  const TriggoNavigationBar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12.0),
+      child: Row(
+        children: [
+          _TriggoNavigationBarItem(
+            routeName: RoutesNames.home,
+            icon: Icons.home,
+          ).build(context),
+          _TriggoNavigationBarItem(
+            routeName: RoutesNames.integrations,
+            icon: Icons.link,
+          ).build(context),
+          _TriggoNavigationBarItem(
+                  routeName: RoutesNames.automations, icon: Icons.bolt_outlined)
+              .build(context),
+        ],
+      ),
+    );
+  }
+}
+
+class _TriggoNavigationBarItem {
+  final IconData? icon;
+  final String routeName;
+
+  const _TriggoNavigationBarItem({required this.icon, required this.routeName});
+
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => CardBloc(),
+      child: Builder(
+        builder: (context) {
+          return Expanded(
+            child: GestureDetector(
+              onTap: () {
+                if (ModalRoute.of(context)?.settings.name != routeName) {
+                  Navigator.of(context).pushNamedAndRemoveUntil(
+                      routeName, (route) => route.settings.name == routeName);
+                }
+              },
+              onTapDown: (_) => context.read<CardBloc>().add(CardEvent.press),
+              onTapUp: (_) => context.read<CardBloc>().add(CardEvent.release),
+              onTapCancel: () =>
+                  context.read<CardBloc>().add(CardEvent.release),
+              child: BlocBuilder<CardBloc, bool>(
+                builder: (context, isPressed) {
+                  return Card(
+                    color: isPressed ? lightContainer : Colors.grey[100],
+                    child: SizedBox(
+                      height: 80,
+                      child: Center(
+                        child: Icon(
+                          icon,
+                          size: 40,
+                          color: isPressed
+                              ? Theme.of(context).colorScheme.primary
+                              : Theme.of(context).textTheme.titleMedium?.color,
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/mobile/lib/app/widgets/navigation_bar.triggo.dart
+++ b/mobile/lib/app/widgets/navigation_bar.triggo.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:triggo/app/features/card/bloc/card_bloc.dart';
 import 'package:triggo/app/routes/routes_names.dart';
 import 'package:triggo/app/theme/colors/colors.dart';
@@ -15,15 +16,16 @@ class TriggoNavigationBar extends StatelessWidget {
         children: [
           _TriggoNavigationBarItem(
             routeName: RoutesNames.home,
-            icon: Icons.home,
+            iconAsset: 'assets/icons/home.svg',
           ).build(context),
           _TriggoNavigationBarItem(
             routeName: RoutesNames.integrations,
-            icon: Icons.link,
+            iconAsset: 'assets/icons/link.svg',
           ).build(context),
           _TriggoNavigationBarItem(
-                  routeName: RoutesNames.automations, icon: Icons.bolt_outlined)
-              .build(context),
+            routeName: RoutesNames.automations,
+            iconAsset: 'assets/icons/bolt.svg',
+          ).build(context),
         ],
       ),
     );
@@ -31,10 +33,11 @@ class TriggoNavigationBar extends StatelessWidget {
 }
 
 class _TriggoNavigationBarItem {
-  final IconData? icon;
+  final String iconAsset;
   final String routeName;
 
-  const _TriggoNavigationBarItem({required this.icon, required this.routeName});
+  const _TriggoNavigationBarItem(
+      {required this.iconAsset, required this.routeName});
 
   Widget build(BuildContext context) {
     return BlocProvider(
@@ -60,12 +63,13 @@ class _TriggoNavigationBarItem {
                     child: SizedBox(
                       height: 80,
                       child: Center(
-                        child: Icon(
-                          icon,
-                          size: 40,
+                        child: SvgPicture.asset(
+                          iconAsset,
                           color: isPressed
                               ? Theme.of(context).colorScheme.primary
                               : Theme.of(context).textTheme.titleMedium?.color,
+                          width: 32,
+                          height: 32,
                         ),
                       ),
                     ),

--- a/mobile/lib/app/widgets/scaffold.triggo.dart
+++ b/mobile/lib/app/widgets/scaffold.triggo.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:triggo/app/widgets/navigation_bar.triggo.dart';
+
+class BaseScaffold extends StatelessWidget {
+  final Widget body;
+
+  const BaseScaffold({super.key, required this.body});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: body,
+      bottomNavigationBar: const TriggoNavigationBar(),
+    );
+  }
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -39,6 +39,9 @@ flutter:
   assets:
     - assets/icons/logo.svg
     - assets/icons/bubbles.svg
+    - assets/icons/home.svg
+    - assets/icons/link.svg
+    - assets/icons/bolt.svg
 
   uses-material-design: true
 


### PR DESCRIPTION
I added a navigation bar

To add the navigation bar to a Page, you just need to replace your classic `Scaffold` by a `BaseScaffold`

I also created a base for the Automation page, so that we can navigate freely without going into a Placeholder.

Here's a little example of how it looks:
![image](https://github.com/user-attachments/assets/02f1ff4e-45e5-44b1-973c-2a8125dd759d)
