### PR TITLE
fix(backend): remove useless providers field in action parameter in create automation dto

### DIFF
--- a/backend/Zeus.Api.Presentation.Web/Contracts/Automations/CreateAutomationRequest.cs
+++ b/backend/Zeus.Api.Presentation.Web/Contracts/Automations/CreateAutomationRequest.cs
@@ -30,6 +30,5 @@ public record CreateAutomationActionRequest(
 public record CreateAutomationActionParameterRequest(
     string Identifier,
     string Value,
-    AutomationActionParameterType Type,
-    Guid[] Providers
+    AutomationActionParameterType Type
 );


### PR DESCRIPTION
I removed useless property `Providers` in action parameter of create automation dto.