### PR TITLE
fix(backend): integrate IntegrationId in unique key of integration tokens

### DIFF
--- a/backend/Zeus.Api.Infrastructure/Migrations/20250115142308_FixIntegrationsTokenPKConstraint.Designer.cs
+++ b/backend/Zeus.Api.Infrastructure/Migrations/20250115142308_FixIntegrationsTokenPKConstraint.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Zeus.Api.Domain.Authentication.AuthenticationMethodAggregate.Enums;
@@ -15,9 +16,11 @@ using Zeus.Common.Domain.Integrations.IntegrationAggregate.Enums;
 namespace Zeus.Api.Infrastructure.Migrations
 {
     [DbContext(typeof(ZeusDbContext))]
-    partial class ZeusDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250115142308_FixIntegrationsTokenPKConstraint")]
+    partial class FixIntegrationsTokenPKConstraint
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Zeus.Api.Infrastructure/Migrations/20250115142308_FixIntegrationsTokenPKConstraint.cs
+++ b/backend/Zeus.Api.Infrastructure/Migrations/20250115142308_FixIntegrationsTokenPKConstraint.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Zeus.Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixIntegrationsTokenPKConstraint : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_IntegrationTokens",
+                table: "IntegrationTokens");
+
+            migrationBuilder.DropIndex(
+                name: "IX_IntegrationTokens_IntegrationId",
+                table: "IntegrationTokens");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_IntegrationTokens",
+                table: "IntegrationTokens",
+                columns: new[] { "IntegrationId", "TokenType", "TokenUsage" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_IntegrationTokens",
+                table: "IntegrationTokens");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_IntegrationTokens",
+                table: "IntegrationTokens",
+                columns: new[] { "TokenValue", "TokenType", "TokenUsage" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IntegrationTokens_IntegrationId",
+                table: "IntegrationTokens",
+                column: "IntegrationId");
+        }
+    }
+}

--- a/backend/Zeus.Api.Infrastructure/Persistence/Configurations/IntegrationsConfiguration.cs
+++ b/backend/Zeus.Api.Infrastructure/Persistence/Configurations/IntegrationsConfiguration.cs
@@ -57,7 +57,7 @@ public class IntegrationsConfiguration : IEntityTypeConfiguration<Integration>
         {
             tb.ToTable("IntegrationTokens");
             tb.WithOwner().HasForeignKey("IntegrationId");
-            tb.HasKey("Value", "Type", "Usage");
+            tb.HasKey("IntegrationId", "Type", "Usage");
             tb.Property(t => t.Value)
                 .HasColumnName("TokenValue")
                 .HasMaxLength(TokenValueMaxLength);


### PR DESCRIPTION
I replaced the `Value` PK component,  by the `ÌntegrationId` in the `IntegrationToken` EF configuration.