### PR TITLE
Fix automation providers in EF configuration and missing integration tokens mapping

### DIFF
--- a/backend/Zeus.Api.Infrastructure/Migrations/20250116113311_FixAutomationProvidersConfiguration.Designer.cs
+++ b/backend/Zeus.Api.Infrastructure/Migrations/20250116113311_FixAutomationProvidersConfiguration.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Zeus.Api.Domain.Authentication.AuthenticationMethodAggregate.Enums;
@@ -15,9 +16,11 @@ using Zeus.Common.Domain.Integrations.IntegrationAggregate.Enums;
 namespace Zeus.Api.Infrastructure.Migrations
 {
     [DbContext(typeof(ZeusDbContext))]
-    partial class ZeusDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250116113311_FixAutomationProvidersConfiguration")]
+    partial class FixAutomationProvidersConfiguration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Zeus.Api.Infrastructure/Migrations/20250116113311_FixAutomationProvidersConfiguration.cs
+++ b/backend/Zeus.Api.Infrastructure/Migrations/20250116113311_FixAutomationProvidersConfiguration.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Zeus.Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixAutomationProvidersConfiguration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_AutomationTriggerProviders",
+                table: "AutomationTriggerProviders");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_AutomationTriggerProviders",
+                table: "AutomationTriggerProviders",
+                columns: new[] { "TriggerId", "ProviderId" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_AutomationTriggerProviders",
+                table: "AutomationTriggerProviders");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_AutomationTriggerProviders",
+                table: "AutomationTriggerProviders",
+                column: "TriggerId");
+        }
+    }
+}

--- a/backend/Zeus.Api.Infrastructure/Persistence/Configurations/AutomationsConfiguration.cs
+++ b/backend/Zeus.Api.Infrastructure/Persistence/Configurations/AutomationsConfiguration.cs
@@ -4,11 +4,9 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Zeus.Common.Domain.AutomationAggregate;
 using Zeus.Common.Domain.AutomationAggregate.Entities;
 using Zeus.Common.Domain.AutomationAggregate.ValueObjects;
-using Zeus.Common.Domain.Integrations.IntegrationAggregate.ValueObjects;
 using Zeus.Common.Domain.UserAggregate;
 
 namespace Zeus.Api.Infrastructure.Persistence.Configurations;
-
 public sealed class AutomationsConfiguration : IEntityTypeConfiguration<Automation>
 {
     private const int ParameterIdentifierMaxLength = 300;
@@ -86,15 +84,18 @@ public sealed class AutomationsConfiguration : IEntityTypeConfiguration<Automati
 
     private static void ConfigureAutomationActionProvidersTable(OwnedNavigationBuilder<Automation, AutomationAction> actions)
     {
-        actions.OwnsMany(x => x.Providers, providers =>
+        actions.OwnsMany(x => x.Providers, provider =>
         {
-            providers.ToTable("AutomationActionProviders");
-            providers.WithOwner().HasForeignKey("ActionId");
-            providers.Property<IntegrationId>("ProviderId")
-                .HasConversion(x => x.Value, x => new IntegrationId(x))
+            provider.ToTable("AutomationActionProviders");
+            provider.WithOwner().HasForeignKey("ActionId");
+
+            provider.Property(x => x.Value)
+                .HasColumnName("ProviderId")
                 .IsRequired();
-            providers.HasKey("ActionId", "ProviderId");
+            provider.HasKey("ActionId", "Value");
         });
+        actions.Navigation(x => x.Providers).Metadata.SetField("_providers");
+        actions.Navigation(x => x.Providers).UsePropertyAccessMode(PropertyAccessMode.Field);
     }
 
     private static void ConfigureAutomationTriggersTable(EntityTypeBuilder<Automation> builder)
@@ -118,14 +119,16 @@ public sealed class AutomationsConfiguration : IEntityTypeConfiguration<Automati
 
     private static void ConfigureAutomationTriggerProvidersTable(OwnedNavigationBuilder<Automation, AutomationTrigger> trigger)
     {
-        trigger.OwnsMany(x => x.Providers, providers =>
+        trigger.OwnsMany(x => x.Providers, provider =>
         {
-            providers.ToTable("AutomationTriggerProviders");
-            providers.WithOwner().HasForeignKey("TriggerId");
-            providers.HasKey("TriggerId");
-            providers.Property<IntegrationId>("ProviderId")
-                .HasConversion(x => x.Value, x => new IntegrationId(x))
+            provider.ToTable("AutomationTriggerProviders");
+            provider.WithOwner().HasForeignKey("TriggerId");
+            provider.HasKey("TriggerId");
+
+            provider.Property(x => x.Value)
+                .HasColumnName("ProviderId")
                 .IsRequired();
+            provider.HasKey("TriggerId", "Value");
         });
         trigger.Navigation(x => x.Providers).Metadata.SetField("_providers");
         trigger.Navigation(x => x.Providers).UsePropertyAccessMode(PropertyAccessMode.Field);

--- a/backend/Zeus.Common.Domain/Integrations/IntegrationAggregate/DiscordIntegration.cs
+++ b/backend/Zeus.Common.Domain/Integrations/IntegrationAggregate/DiscordIntegration.cs
@@ -15,9 +15,10 @@ public sealed class DiscordIntegration : Integration
         IntegrationId id,
         UserId ownerId,
         string clientId,
+        List<IntegrationToken> tokens,
         DateTime updatedAt,
         DateTime createdAt)
-        : base(id, IntegrationType.Discord, ownerId, clientId, updatedAt, createdAt)
+        : base(id, IntegrationType.Discord, ownerId, clientId, tokens, updatedAt, createdAt)
     {
     }
 
@@ -43,6 +44,7 @@ public sealed class DiscordIntegration : Integration
             IntegrationId.CreateUnique(),
             ownerId,
             clientId,
+            [],
             DateTime.UtcNow,
             DateTime.UtcNow);
     }

--- a/backend/Zeus.Common.Domain/Integrations/IntegrationAggregate/GmailIntegration.cs
+++ b/backend/Zeus.Common.Domain/Integrations/IntegrationAggregate/GmailIntegration.cs
@@ -14,9 +14,10 @@ public sealed class GmailIntegration : Integration
         IntegrationId id,
         UserId ownerId,
         string clientId,
+        List<IntegrationToken> tokens,
         DateTime updatedAt,
         DateTime createdAt)
-        : base(id, IntegrationType.Gmail, ownerId, clientId, updatedAt, createdAt)
+        : base(id, IntegrationType.Gmail, ownerId, clientId, tokens, updatedAt, createdAt)
     {
     }
 
@@ -42,6 +43,7 @@ public sealed class GmailIntegration : Integration
             IntegrationId.CreateUnique(),
             ownerId,
             clientId,
+            [],
             DateTime.UtcNow,
             DateTime.UtcNow);
     }

--- a/backend/Zeus.Common.Domain/Integrations/IntegrationAggregate/Integration.cs
+++ b/backend/Zeus.Common.Domain/Integrations/IntegrationAggregate/Integration.cs
@@ -17,6 +17,7 @@ public abstract class Integration : AggregateRoot<IntegrationId>
         IntegrationType type,
         UserId ownerId,
         string clientId,
+        List<IntegrationToken> tokens,
         DateTime updatedAt,
         DateTime createdAt)
         : base(id, updatedAt, createdAt)
@@ -24,6 +25,7 @@ public abstract class Integration : AggregateRoot<IntegrationId>
         Type = type;
         OwnerId = ownerId;
         ClientId = clientId;
+        _tokens = tokens;
     }
 
 #pragma warning disable CS8618

--- a/backend/Zeus.Common.Domain/Integrations/IntegrationAggregate/LeagueOfLegendsIntegration.cs
+++ b/backend/Zeus.Common.Domain/Integrations/IntegrationAggregate/LeagueOfLegendsIntegration.cs
@@ -10,9 +10,10 @@ public sealed class LeagueOfLegendsIntegration : Integration
         IntegrationId id,
         UserId ownerId,
         string clientId,
+        List<IntegrationToken> tokens,
         DateTime updatedAt,
         DateTime createdAt)
-        : base(id, IntegrationType.LeagueOfLegends, ownerId, clientId, updatedAt, createdAt)
+        : base(id, IntegrationType.LeagueOfLegends, ownerId, clientId, tokens, updatedAt, createdAt)
     {
     }
 
@@ -36,6 +37,7 @@ public sealed class LeagueOfLegendsIntegration : Integration
             IntegrationId.CreateUnique(),
             ownerId,
             clientId,
+            [],
             DateTime.UtcNow,
             DateTime.UtcNow);
     }

--- a/backend/Zeus.Common.Domain/Integrations/IntegrationAggregate/NotionIntegration.cs
+++ b/backend/Zeus.Common.Domain/Integrations/IntegrationAggregate/NotionIntegration.cs
@@ -8,16 +8,16 @@ using Zeus.Common.Domain.UserAggregate.ValueObjects;
 namespace Zeus.Common.Domain.Integrations.IntegrationAggregate;
 
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]
-
 public sealed class NotionIntegration : Integration
 {
     public NotionIntegration(
         IntegrationId id,
         UserId ownerId,
         string clientId,
+        List<IntegrationToken> tokens,
         DateTime updatedAt,
         DateTime createdAt)
-        : base(id, IntegrationType.Notion, ownerId, clientId, updatedAt, createdAt)
+        : base(id, IntegrationType.Notion, ownerId, clientId, tokens, updatedAt, createdAt)
     {
     }
 
@@ -42,6 +42,7 @@ public sealed class NotionIntegration : Integration
             IntegrationId.CreateUnique(),
             ownerId,
             clientId,
+            [],
             DateTime.UtcNow,
             DateTime.UtcNow);
     }

--- a/backend/Zeus.Common.Domain/Integrations/IntegrationAggregate/OpenAiIntegration.cs
+++ b/backend/Zeus.Common.Domain/Integrations/IntegrationAggregate/OpenAiIntegration.cs
@@ -14,9 +14,10 @@ public sealed class OpenAiIntegration : Integration
         IntegrationId id,
         UserId ownerId,
         string clientId,
+        List<IntegrationToken> tokens,
         DateTime updatedAt,
         DateTime createdAt)
-        : base(id, IntegrationType.OpenAi, ownerId, clientId, updatedAt, createdAt)
+        : base(id, IntegrationType.OpenAi, ownerId, clientId, tokens, updatedAt, createdAt)
     {
     }
 
@@ -41,6 +42,7 @@ public sealed class OpenAiIntegration : Integration
             IntegrationId.CreateUnique(),
             ownerId,
             clientId,
+            [],
             DateTime.UtcNow,
             DateTime.UtcNow);
     }

--- a/backend/Zeus.Daemon.Infrastructure/Mapping/SynchronizationMappers.cs
+++ b/backend/Zeus.Daemon.Infrastructure/Mapping/SynchronizationMappers.cs
@@ -1,9 +1,9 @@
-﻿using Zeus.Common.Domain.AutomationAggregate.Enums;
+﻿using Zeus.Api.Presentation.gRPC.Contracts;
+using Zeus.Common.Domain.AutomationAggregate.Enums;
 using Zeus.Common.Domain.AutomationAggregate.ValueObjects;
 using Zeus.Common.Domain.Integrations.IntegrationAggregate;
 using Zeus.Common.Domain.Integrations.IntegrationAggregate.ValueObjects;
 using Zeus.Common.Domain.UserAggregate.ValueObjects;
-using Zeus.Daemon.Domain.Automations;
 
 using Automation = Zeus.Common.Domain.AutomationAggregate.Automation;
 using AutomationAction = Zeus.Common.Domain.AutomationAggregate.Entities.AutomationAction;
@@ -11,7 +11,10 @@ using AutomationActionParameter = Zeus.Common.Domain.AutomationAggregate.ValueOb
 using AutomationTrigger = Zeus.Common.Domain.AutomationAggregate.Entities.AutomationTrigger;
 using AutomationTriggerParameter = Zeus.Common.Domain.AutomationAggregate.ValueObjects.AutomationTriggerParameter;
 using Integration = Zeus.Common.Domain.Integrations.IntegrationAggregate.Integration;
+using IntegrationToken = Zeus.Common.Domain.Integrations.IntegrationAggregate.ValueObjects.IntegrationToken;
 using IntegrationType = Zeus.Common.Domain.Integrations.Common.Enums.IntegrationType;
+using RegistrableAutomation = Zeus.Daemon.Domain.Automations.RegistrableAutomation;
+using IntegrationTokenUsage = Zeus.Common.Domain.Integrations.IntegrationAggregate.Enums.IntegrationTokenUsage;
 
 namespace Zeus.Daemon.Infrastructure.Mapping;
 
@@ -68,9 +71,7 @@ public static class SynchronizationMappers
             action.Rank,
             action.Parameters.Select(p => new AutomationActionParameter
             {
-                Identifier = p.Identifier,
-                Value = p.Value,
-                Type = Enum.Parse<AutomationActionParameterType>(p.Type)
+                Identifier = p.Identifier, Value = p.Value, Type = Enum.Parse<AutomationActionParameterType>(p.Type)
             }).ToList(),
             action.Providers.Select(p => new IntegrationId(Guid.Parse(p))).ToList()
         );
@@ -84,14 +85,15 @@ public static class SynchronizationMappers
         var clientId = integration.ClientId;
         var updatedAt = DateTimeOffset.FromUnixTimeSeconds(integration.UpdatedAt).DateTime;
         var createdAt = DateTimeOffset.FromUnixTimeSeconds(integration.CreatedAt).DateTime;
+        var tokens = integration.Tokens.Select(t => new IntegrationToken(t.Value, t.Type, Enum.Parse<IntegrationTokenUsage>(t.Usage.ToString()))).ToList();
 
         return type switch
         {
-            IntegrationType.Discord => new DiscordIntegration(id, ownerId, clientId, updatedAt, createdAt),
-            IntegrationType.Gmail => new GmailIntegration(id, ownerId, clientId, updatedAt, createdAt),
-            IntegrationType.Notion => new NotionIntegration(id, ownerId, clientId, updatedAt, createdAt),
-            IntegrationType.OpenAi => new OpenAiIntegration(id, ownerId, clientId, updatedAt, createdAt),
-            IntegrationType.LeagueOfLegends => new LeagueOfLegendsIntegration(id, ownerId, clientId, updatedAt, createdAt),
+            IntegrationType.Discord => new DiscordIntegration(id, ownerId, clientId, tokens, updatedAt, createdAt),
+            IntegrationType.Gmail => new GmailIntegration(id, ownerId, clientId, tokens, updatedAt, createdAt),
+            IntegrationType.Notion => new NotionIntegration(id, ownerId, clientId, tokens, updatedAt, createdAt),
+            IntegrationType.OpenAi => new OpenAiIntegration(id, ownerId, clientId, tokens, updatedAt, createdAt),
+            IntegrationType.LeagueOfLegends => new LeagueOfLegendsIntegration(id, ownerId, clientId, tokens, updatedAt, createdAt),
             _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
         };
     }


### PR DESCRIPTION
In common domain, the mapping of integration tokens was missing and I also fixed the EF configuration error of the provider ids in an automation. It was due to confusion of my part between `.Property` method and `.HasColumnName`.