### PR TITLE
fix: docker compose with production apk build

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,10 @@ docker-compose up
 ```
 
 ### Production Version
-In the production environment, you must build the mobile application. To include the mobile build, set the `BUILD_MOBILE` environment variable before running the commands:
+In the production environment, you must build the mobile application. To include the mobile build, you have to use the profile production in the docker-compose command:
 
-#### Windows PowerShell
-```powershell
-$env:BUILD_MOBILE="true"
-docker-compose up --build
 ```
-
-#### Linux/macOS
-```sh
-export BUILD_MOBILE=true
-docker-compose up --build
+docker-compose --profile production up --build
 ```
 
 ---

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -97,16 +97,29 @@ services:
       - zeus-api-grpc
       - zeus-message-broker
 
-  mobile-app:
-    container_name: mobile-app
+  mobile-base:
+    container_name: mobile-base
+    restart: no
+    build:
+      context: mobile/
+      dockerfile: Dockerfile.base
+    image: mobile-base
+    profiles:
+      - production
+    volumes:
+      - shared_volume:/common
+
+  mobile-apk:
+    container_name: mobile-apk
     restart: no
     build:
       context: mobile/
       dockerfile: Dockerfile.prod
-      args:
-        BUILD_MOBILE: ${BUILD_MOBILE:-false}
-    environment:
-      - BUILD_MOBILE=${BUILD_MOBILE:-false}
+    profiles:
+      - production
+    depends_on:
+      - mobile-base
+    image: mobile-apk:local
     volumes:
       - shared_volume:/common
 

--- a/mobile/Dockerfile.prod
+++ b/mobile/Dockerfile.prod
@@ -8,6 +8,8 @@ COPY . .
 
 RUN flutter pub get
 
-RUN if [ "$BUILD_MOBILE" = "true" ]; then flutter build apk --dart-define-from-file=.env; fi
+RUN flutter build apk --dart-define-from-file=.env
 
-CMD ["sh", "-c", "if [ \"$BUILD_MOBILE\" = \"true\" ]; then flutter build apk --dart-define-from-file=.env && cp build/app/outputs/apk/release/Triggo-release.apk /common/Triggo-release.apk; else echo 'Skipping mobile build'; fi"]
+RUN mkdir -p /common
+
+RUN cp build/app/outputs/apk/release/Triggo-release.apk /common/Triggo-release.apk


### PR DESCRIPTION
I updated the way the mobile apk is build. Now we'll use docker profiles in order to build apk or not